### PR TITLE
fix sql_obj() may fail with "undefined subroutine croak()"

### DIFF
--- a/lib/SQL/Object.pm
+++ b/lib/SQL/Object.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use utf8;
 use Exporter qw/import/;
+use Carp;
 
 our @EXPORT_OK = qw/sql_obj sql_type/;
 

--- a/t/02_init_named.t
+++ b/t/02_init_named.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test::More;
+use SQL::Object qw/sql_obj/;
+
+subtest 'carp works' => sub {
+    eval { my $sql = sql_obj(':missing_name', {}) };
+    like $@, qr/missing_name does not exists in hash/;
+};
+
+done_testing;
+


### PR DESCRIPTION
sql_obj() has a call to croak(), but "use Carp" is missing.
So user script may get "undefined subroutine croak" if it does not use Carp too.
"use Carp" was added to fix this.

New test 02_init_named.t to cover the issue.
